### PR TITLE
Lock py version

### DIFF
--- a/ghapp/Dockerfile
+++ b/ghapp/Dockerfile
@@ -1,3 +1,4 @@
-FROM python:3.6.8-alpine
+FROM alpine:3.8
+RUN apk add --no-cache python3=3.6.8-r0 py3-cryptography bash
 COPY . /ghapp
-RUN pip install /ghapp
+RUN pip3 install /ghapp

--- a/ghapp/Dockerfile
+++ b/ghapp/Dockerfile
@@ -1,6 +1,3 @@
-FROM alpine:latest
-RUN apk add --no-cache python3 py3-cryptography bash
-
+FROM python:3.6.8-alpine
 COPY . /ghapp
-
-RUN pip3 install /ghapp
+RUN pip install /ghapp

--- a/ghapp/ghapp/cattrs.py
+++ b/ghapp/ghapp/cattrs.py
@@ -51,7 +51,7 @@ def _register_ignore_optional_none(cls, converter=None):
     prev_unstructure = converter._unstructure_func.dispatch(cls)
     optional_attrs = {
         f.name for f in attr.fields(cls)
-        if isinstance(f.type, typing._GenericAlias) and type(None) in f.type.__args__
+        if isinstance(f.type, typing._Union) and type(None) in f.type.__args__
     }
 
     def unstructure_ignoring_optional_none(obj):


### PR DESCRIPTION
Issue:
- python3.7 has no longer `typing._Union`
- previous fix is to check field type if is instance of typing generic annotation instead (i.e. List, Set, Map are in scope as well)

This fix:
- lock python version=3.6.8
- however, alpine latest `3.9` cannot find this package in `apk`
- image `python:3.6-alpine3.8` has issue to install cryptography library, so it is not a choice either